### PR TITLE
Changed MarkerClient to support multiple markers at a time

### DIFF
--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -23,8 +23,7 @@ ROS3D.MarkerClient = function(options) {
   this.tfClient = options.tfClient;
   this.rootObject = options.rootObject || new THREE.Object3D();
 
-  // current marker that is displayed
-  // this.currentMarker = null;
+  // Markers that are displayed (Map id--Marker)
   this.markers = {};
 
   // subscribe to the topic


### PR DESCRIPTION
I've updated the MarkerClient to support multiple markers at a time. The markers are stored in a map, indexed by their id, so new markers with the same ID should overwrite existing ones.
