### PR TITLE
Removed memory leak from MarkerClient

### DIFF
--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -39,6 +39,9 @@ ROS3D.MarkerClient = function(options) {
       message : message
     });
 
+    // remove old marker from Three.Object3D children buffer
+    that.rootObject.remove(that.markers[message.id]);
+
     that.markers[message.id] = new ROS3D.SceneNode({
       frameID : message.header.frame_id,
       tfClient : that.tfClient,


### PR DESCRIPTION
While the internal that.markers map did not have duplicates, the rootObject.children list still remembered a reference to the old marker and thereby prevented the garbage collector from eating it.
