### PR TITLE
Urdf shapes fix

### DIFF
--- a/src/urdf/Urdf.js
+++ b/src/urdf/Urdf.js
@@ -58,6 +58,44 @@ ROS3D.Urdf = function(options) {
             object : mesh
           });
           this.add(sceneNode);
+        } else {
+          var colorMaterial, shapeMesh;
+          // Save frameID
+          var frameID = '/' + link.name;
+          // Save color material
+          var color = link.visual.material.color;          
+          if (color === null)
+            colorMaterial = ROS3D.makeColorMaterial(0, 0, 0, 1);
+          else
+            colorMaterial = ROS3D.makeColorMaterial(color.r, color.g, color.b, color.a);
+          // Create a shape
+          switch (link.visual.geometry.type) {
+              case ROSLIB.URDF_BOX:
+                  var dimension = link.visual.geometry.dimension;
+                  var shapeGeom = new THREE.CubeGeometry(dimension.x, dimension.y, dimension.z);
+                  shapeMesh = new THREE.Mesh(shapeGeom, colorMaterial);
+                  break;
+              case ROSLIB.URDF_CYLINDER:
+                  var radius = link.visual.geometry.radius;
+                  var length = link.visual.geometry.length;
+                  var shapeGeom = new THREE.CylinderGeometry(radius, radius, length, 16, 1, false);
+                  shapeMesh = new THREE.Mesh(shapeGeom, colorMaterial);
+                  shapeMesh.useQuaternion = true;
+                  shapeMesh.quaternion.setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI * 0.5);
+                  break;
+              case ROSLIB.URDF_SPHERE:
+                  var shapeGeom = new THREE.SphereGeometry(link.visual.geometry.radius, 16);
+                  shapeMesh = new THREE.Mesh(shapeGeom, colorMaterial);
+                  break;
+          }
+          // Create a scene node with the shape
+          var sceneNode = new ROS3D.SceneNode({
+              frameID: frameID,
+              pose: link.visual.origin,
+              tfClient: tfClient,
+              object: shapeMesh
+          });
+          this.add(sceneNode);
         }
       }
     }


### PR DESCRIPTION
Now you can draw other shapes.

Example, try:
roslaunch urdf_tutorial display.launch model:=urdf/05-visual.urdf
rosrun tf2_web_republisher tf2_web_republisher
roslaunch rosbridge_server rosbridge_websocket.launch

and open on browser: examples/urdf.html

![r2d2](https://f.cloud.github.com/assets/4551246/2172364/50b26828-9592-11e3-8e9f-1d330cee0e88.png)
