### PR TITLE
Correction on measure unit for cellSize

### DIFF
--- a/src/models/Grid.js
+++ b/src/models/Grid.js
@@ -7,20 +7,20 @@
  *
  * @constructor
  * @param options - object with following keys:
- *  * size (optional) - the size of the grid
+ *  * size (optional) - The number of cells of the grid
  *  * color (optional) - the line color of the grid, like '#cccccc'
  *  * lineWidth (optional) - the width of the lines in the grid
- *  * cellSize (optional) - the size of the cell in the grid
+ *  * cellSize (optional) - The length, in meters, of the side of each cell
  */
 ROS3D.Grid = function(options) {
   options = options || {};
-  var size = options.size || 50;
+  var size = options.size || 10;
   var color = options.color || '#cccccc';
   var lineWidth = options.lineWidth || 1;
-  var cellSize = options.cellSize || 50;
+  var cellSize = options.cellSize || 1;
 
   // create the mesh
-  THREE.Mesh.call(this, new THREE.PlaneGeometry(size, size, cellSize, cellSize),
+  THREE.Mesh.call(this, new THREE.PlaneGeometry(size*cellSize, size*cellSize, size, size),
       new THREE.MeshBasicMaterial({
         color : color,
         wireframe : true,


### PR DESCRIPTION
the difference between last revision end now using the familiar SI unit:
"cellSize" in meter and "Size" is number of cells. More similar a grid object on rviz
