### PR TITLE
multi-touch zooming: consider movement along X and Y axis

### DIFF
--- a/src/visualization/interaction/OrbitControls.js
+++ b/src/visualization/interaction/OrbitControls.js
@@ -106,7 +106,7 @@ ROS3D.OrbitControls = function(options) {
   }
 
   /**
-   * Handle the movemove 3D event.
+   * Handle the mousemove 3D event.
    *
    * @param event3D - the 3D event to handle
    */


### PR DESCRIPTION
pinching solely along the X axis was being ignored by just looking at the y component of zoomDelta.
