### PR TITLE
Fix for ROS3D.Viewer clear color, use parseInt in order to convert hex s...

### DIFF
--- a/src/visualization/Viewer.js
+++ b/src/visualization/Viewer.js
@@ -37,7 +37,7 @@ ROS3D.Viewer = function(options) {
   this.renderer = new THREE.WebGLRenderer({
     antialias : this.antialias
   });
-  this.renderer.setClearColorHex(parseInt(background.replace('#', '0x'), 16), 1.0);
+  this.renderer.setClearColor(parseInt(background.replace('#', '0x'), 16), 1.0);
   this.renderer.sortObjects = false;
   this.renderer.setSize(width, height);
   this.renderer.shadowMapEnabled = false;


### PR DESCRIPTION
Clear color was always (0,0,0) here. I had to convert the string representation
of the hex number to int and call setClearColorHex to get the clear color working.
