### PR TITLE
Change linePrecision on raycaster

### DIFF
--- a/src/visualization/interaction/MouseHandler.js
+++ b/src/visualization/interaction/MouseHandler.js
@@ -67,6 +67,7 @@ ROS3D.MouseHandler.prototype.processDomEvent = function(domEvent) {
   // use the THREE raycaster
   var mouseRaycaster = new THREE.Raycaster(this.camera.position.clone(), vector.sub(
       this.camera.position).normalize());
+  mouseRaycaster.linePrecision = 0.001;
   var mouseRay = mouseRaycaster.ray;
 
   // make our 3d mouse event


### PR DESCRIPTION
Default THREE.Raycaster linePrecision is 1, meaning that any InteractiveMarker with THREE.Line geometry will be selected when the mouse is within 1m of any point on any line in the marker, making interaction difficult or impossible. This changes the precision so that the marker is only highlighted when the mouse is actually hovering over a line in the marker.
