### PR TITLE
Fix never-set orientation of Interactive Markers

### DIFF
--- a/src/interactivemarkers/InteractiveMarkerControl.js
+++ b/src/interactivemarkers/InteractiveMarkerControl.js
@@ -190,7 +190,7 @@ ROS3D.InteractiveMarkerControl = function(options) {
         // get the current pose as a ROSLIB.Pose...
         var newPose = new ROSLIB.Pose({
           position : markerHelper.position,
-          quaternion : markerHelper.quaternion
+          orientation : markerHelper.quaternion
         });
         // so we can apply the transform provided by the TFClient
         newPose.applyTransform(new ROSLIB.Transform(transformMsg));


### PR DESCRIPTION
Fix typo in setting Pose orientation argument, when creating Markers for Controls based on tfClient transforms.

Fixes problem where all Markers in InteractiveMarkerControls (potentially those based in a non-empty `""` tf frame) had an identity orientation / quaternion -- i.e. none of the rotations set in the Pose of the Marker seemed to do anything, though the position transform of the pose did work.

This just fixes a typo in the argument to Pose(). Initial testing fixed the problem, though I haven't done any thorough testing yet.
