### PR TITLE
Added Resize 3D Viewer

### DIFF
--- a/src/visualization/Viewer.js
+++ b/src/visualization/Viewer.js
@@ -131,7 +131,7 @@ ROS3D.Viewer.prototype.addObject = function(object, selectable) {
  * @param height - new height value
  */
 ROS3D.Viewer.prototype.resize = function(width, height) {
-  	this.camera.aspect = width / height;
-    this.camera.updateProjectionMatrix();
-  	this.renderer.setSize(width, height);
+  this.camera.aspect = width / height;
+  this.camera.updateProjectionMatrix();
+  this.renderer.setSize(width, height);
 };

--- a/src/visualization/Viewer.js
+++ b/src/visualization/Viewer.js
@@ -123,3 +123,15 @@ ROS3D.Viewer.prototype.addObject = function(object, selectable) {
     this.scene.add(object);
   }
 };
+
+/**
+ * Resize 3D viewer
+ *
+ * @param width - new width value
+ * @param height - new height value
+ */
+ROS3D.Viewer.prototype.resize = function(width, height) {
+  	this.camera.aspect = width / height;
+    this.camera.updateProjectionMatrix();
+  	this.renderer.setSize(width, height);
+};


### PR DESCRIPTION
Now you can resize the Viewer with a function `resize(with, height)`:

example:
```javascript
var viewer3D = new ROS3D.Viewer({
        divID: divName,
        width: window.innerWidth,
        height: window.innerHeight,
        antialias: true
    });

window.onresize = function(event) {
   viewer3D.resize(window.innerWidth, window.innerHeight);
};
```

![resize](https://cloud.githubusercontent.com/assets/4551246/8187425/f7094c18-144f-11e5-9e48-1726f0b67e78.gif)