### PR TITLE
Use Material param if it is defined

### DIFF
--- a/src/models/MeshResource.js
+++ b/src/models/MeshResource.js
@@ -59,11 +59,7 @@ ROS3D.MeshResource = function(options) {
       // add a texture to anything that is missing one
       if(material !== null) {
         var setMaterial = function(node, material) {
-          // do not overwrite the material
-          if (typeof node.material === 'undefined') {
-            node.material = material;
-          }
-          //node.material = material;
+          node.material = material;
           if (node.children) {
             for (var i = 0; i < node.children.length; i++) {
               setMaterial(node.children[i], material);


### PR DESCRIPTION
Fix for #112 

Previous logic: If the mesh has a defined material, use it instead of anything else. Only use the new material parameter if the material is undefined. 

New logic: Use the parameter if it is defined. This relegates the decision to the creator of the MeshResource. The URDF will only pass in a valid parameter if the tag is defined in the XML. The Marker will only pass in the parameter if it is set to a non-zero value. 

