### PR TITLE
Fixing "DELETE ALL" action for MarkerArray

### DIFF
--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -78,8 +78,8 @@ ROS3D.MarkerArrayClient = function(options) {
       }
       else if(message.action === 3) { // "DELETE ALL"
         for (var m in that.markers){
-          m.unsubscribeTf();
-          that.rootObject.remove(m);
+          that.markers[m].unsubscribeTf();
+          that.rootObject.remove(that.markers[m]);
         }
         that.markers = {};
       }


### PR DESCRIPTION
`markers` property of `MarkerArrayClient` is an associative array. Iterating over that with for/in loop returns only the key. This commit fixes named indexing that is required to access and delete the marker object.
