### PR TITLE
OrbitControl: swap functionality of middle and right mouse button

### DIFF
--- a/src/visualization/interaction/OrbitControls.js
+++ b/src/visualization/interaction/OrbitControls.js
@@ -87,7 +87,7 @@ ROS3D.OrbitControls = function(options) {
         state = STATE.ROTATE;
         rotateStart.set(event.clientX, event.clientY);
         break;
-      case 1:
+      case 2:
         state = STATE.MOVE;
 
         moveStartNormal = new THREE.Vector3(0, 0, 1);
@@ -100,7 +100,7 @@ ROS3D.OrbitControls = function(options) {
                                                    moveStartCenter,
                                                    moveStartNormal);
         break;
-      case 2:
+      case 1:
         state = STATE.ZOOM;
         zoomStart.set(event.clientX, event.clientY);
         break;


### PR DESCRIPTION
This PR swaps OrbitControl's meaning of middle and right mouse button to enable touchpad-only users to also move around in a scene.

### Old:
Left click: Rotate
Right click: Zoom
Middle click: Move
Mouse wheel: Zoom

### New:
Left click: Rotate
Right click: Move
Middle click: Zoom
Mouse wheel: Zoom

I doubt that anybody with a mouse wheel or trackpad with 2-finger scroll has ever used the right mouse button to zoom. So I think this change will not cause much (if any) confusion.