### PR TITLE
Org scope npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ros3djs",
+  "name": "@robot-web-tools/ros3djs",
   "homepage": "https://www.robotwebtools.org",
   "description": "The standard ROS Javascript Visualization Library",
   "version": "0.17.0-SNAPSHOT",
@@ -27,5 +27,8 @@
     "ros3djs",
     "robot"
   ],
-  "author": "Robot Webtools Team <robot-web-tools@googlegroups.com> (http://robotwebtools.org)"
+  "author": "Robot Webtools Team <robot-web-tools@googlegroups.com> (http://robotwebtools.org)",
+  "directories": {
+    "example": "examples"
+  }
 }


### PR DESCRIPTION
The ros3djs npm package is released as an org scoped package `@robot-web-tools/ros3djs` and as seen:
* https://www.npmjs.com/package/@robot-web-tools/ros3djs
* https://www.npmjs.com/org/robot-web-tools

But I never updated the npm name as recorded in this repo which will prevent later releases from being scoped correctly.