### PR TITLE
Updates from ShaderMaterial to PointsMaterial in Particles.js

### DIFF
--- a/src/sensors/Particles.js
+++ b/src/sensors/Particles.js
@@ -26,50 +26,11 @@ ROS3D.Particles = function(options) {
   var that = this;
   THREE.Object3D.call(this);
 
-  this.vertex_shader = [
-    'attribute vec3 customColor;',
-    'attribute float alpha;',
-    'varying vec3 vColor;',
-    'varying float falpha;',
-    'void main() ',
-    '{',
-    '    vColor = customColor; // set color associated to vertex; use later in fragment shader',
-    '    vec4 mvPosition = modelViewMatrix * vec4( position, 1.0 );',
-    '    falpha = alpha; ',
-    '',
-    '    // option (1): draw particles at constant size on screen',
-    '    // gl_PointSize = size;',
-    '    // option (2): scale particles as objects in 3D space',
-    '    gl_PointSize = ', size, '* ( 300.0 / length( mvPosition.xyz ) );',
-    '    gl_Position = projectionMatrix * mvPosition;',
-    '}'
-    ].join('\n');
-
-  this.fragment_shader = [
-    'uniform sampler2D texture;',
-    'varying vec3 vColor; // colors associated to vertices; assigned by vertex shader',
-    'varying float falpha;',
-    'void main() ',
-    '{',
-    '    // THREE.Material.alphaTest is not evaluated for ShaderMaterial, so we',
-    '    // have to take care of this ourselves.',
-    '    if (falpha < 0.5) discard;',
-    '    // calculates a color for the particle',
-    '    gl_FragColor = vec4( vColor, falpha );',
-    '    // sets particle texture to desired color',
-    '    gl_FragColor = gl_FragColor * texture2D( texture, gl_PointCoord );',
-    '}'
-    ].join('\n');
-
     this.geom = new THREE.Geometry();
     for(var i=0;i<this.max_pts;i++){
         this.geom.vertices.push(new THREE.Vector3( ));
+        this.geom.colors.push( new THREE.Color( options.color ) );
     }
-
-    var customUniforms =
-    {
-        texture:   { type: 't', value: THREE.ImageUtils.loadTexture( texture ) },
-    };
 
     this.attribs =
     {
@@ -77,16 +38,13 @@ ROS3D.Particles = function(options) {
         alpha:         { type: 'f', value: [] }
     };
 
-    this.shaderMaterial = new THREE.ShaderMaterial(
+    this.pointsMaterial = new THREE.PointsMaterial(
     {
-        uniforms:          customUniforms,
-        attributes:        this.attribs,
-        vertexShader:      this.vertex_shader,
-        fragmentShader:    this.fragment_shader,
-        transparent: true,
+        size : size,
+        vertexColors : THREE.VertexColors
     });
 
-    this.ps = new THREE.ParticleSystem( this.geom, this.shaderMaterial );
+    this.ps = new THREE.Points( this.geom, this.pointsMaterial );
     this.sn = null;
 
     this.points = this.geom.vertices;


### PR DESCRIPTION
Hi,

I was having issues with the current implementation using the latest of the [THREE lib](https://github.com/mrdoob/three.js/commit/9b0ae03f8c586659a50681d30e1be6932fd68ca8), and after struggling a bit with my very bad javascript skills, I managed to make it work.

I couldn't generate the build files, since I'm on Ubuntu 16.04 and the commands in the readme file didn't work for me. If someone tells me how to do it, I'd be glad to add the build files to this PR.

I can tell you it works for me, here you can see a screenshot with two laser scans of size 0.1 (different from the default 0.05) and separate colors (different from the default 0xFFA500).

![screenshot from 2018-04-03 16-42-52](https://user-images.githubusercontent.com/4049053/38256485-b4751d2a-375e-11e8-88b4-16b31ca313de.png)