### PR TITLE
Use CBOR compression for PointCloud2

### DIFF
--- a/src/sensors/PointCloud2.js
+++ b/src/sensors/PointCloud2.js
@@ -94,7 +94,7 @@ ROS3D.PointCloud2.prototype.processMessage = function(msg){
   var n, pointRatio = this.points.pointRatio;
 
   if (msg.data.buffer) {
-    this.points.buffer = msg.data.buffer;
+    this.points.buffer.set(msg.data);
     n = msg.height*msg.width / pointRatio;
   } else {
     n = decode64(msg.data, this.points.buffer, msg.point_step, pointRatio);

--- a/src/sensors/PointCloud2.js
+++ b/src/sensors/PointCloud2.js
@@ -80,7 +80,8 @@ ROS3D.PointCloud2.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
     ros : this.ros,
     name : this.topicName,
-    messageType : 'sensor_msgs/PointCloud2'
+    messageType : 'sensor_msgs/PointCloud2',
+    compression: 'cbor'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));
 };

--- a/src/sensors/PointCloud2.js
+++ b/src/sensors/PointCloud2.js
@@ -48,6 +48,7 @@ for(var i=0;i<64;i++){decode64.e[decode64.S.charAt(i)]=i;}
  *  * ros - the ROSLIB.Ros connection handle
  *  * topic - the marker topic to listen to (default: '/points')
  *  * tfClient - the TF client handle to use
+ *  * compression (optional) - message compression (default: 'cbor')
  *  * rootObject (optional) - the root object to add this marker to use for the points.
  *  * max_pts (optional) - number of points to draw (default: 10000)
  *  * pointRatio (optional) - point subsampling ratio (default: 1, no subsampling)
@@ -60,6 +61,7 @@ ROS3D.PointCloud2 = function(options) {
   options = options || {};
   this.ros = options.ros;
   this.topicName = options.topic || '/points';
+  this.compression = options.compression || 'cbor';
   this.points = new ROS3D.Points(options);
   this.rosTopic = undefined;
   this.subscribe();
@@ -81,7 +83,7 @@ ROS3D.PointCloud2.prototype.subscribe = function(){
     ros : this.ros,
     name : this.topicName,
     messageType : 'sensor_msgs/PointCloud2',
-    compression: 'cbor'
+    compression: this.compression
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));
 };


### PR DESCRIPTION
Requires https://github.com/RobotWebTools/rosbridge_suite/pull/364 and https://github.com/RobotWebTools/roslibjs/pull/303

CBOR encoding is perfect for a point cloud.  With this patch I was able to run points clouds of up to 250,000 points at 60fps.  At 500,000 points there is a slight jank when the message is processed.  This is comparable to rviz's performance.