### PR TITLE
Update and normalize EventEmitter2 dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,7 +21,7 @@
      "Robot Webtools Team <robot-web-tools@googlegroups.com> (http://robotwebtools.org)"
   ],
   "dependencies": {
-    "eventemitter2": "asyncly/EventEmitter2#^0.4.14",
+    "eventemitter2": "^4.1.0",
     "threejs": "mrdoob/three.js#r88",
     "roslibjs": "RobotWebTools/roslibjs#0.14.0"
   }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "./build/ros3d.cjs.js",
   "module": "./build/ros3d.esm.js",
   "dependencies": {
-    "eventemitter2": "~2.2.0",
+    "eventemitter2": "^4.1.0",
     "roslib": ">=0.14.0",
     "three": "^0.88.0"
   },


### PR DESCRIPTION
The versions of EventEmitter2 in package.json and bower.json were different, so I normalized and updated them.  This change resolves conflicts with other bower packages which expect a newer version of EventEmitter2.