### PR TITLE
Use single item queue for unreliable topics

### DIFF
--- a/src/navigation/OccupancyGridClient.js
+++ b/src/navigation/OccupancyGridClient.js
@@ -58,6 +58,7 @@ ROS3D.OccupancyGridClient.prototype.subscribe = function(){
     ros : this.ros,
     name : this.topicName,
     messageType : 'nav_msgs/OccupancyGrid',
+    queue_length : 1,
     compression : this.compression
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/Odometry.js
+++ b/src/navigation/Odometry.js
@@ -51,6 +51,7 @@ ROS3D.Odometry.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
     ros : this.ros,
     name : this.topicName,
+    queue_length : 1,
     messageType : 'nav_msgs/Odometry'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/Path.js
+++ b/src/navigation/Path.js
@@ -45,6 +45,7 @@ ROS3D.Path.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'nav_msgs/Path'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/Point.js
+++ b/src/navigation/Point.js
@@ -46,6 +46,7 @@ ROS3D.Point.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'geometry_msgs/PointStamped'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/Polygon.js
+++ b/src/navigation/Polygon.js
@@ -45,6 +45,7 @@ ROS3D.Polygon.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'geometry_msgs/PolygonStamped'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/Pose.js
+++ b/src/navigation/Pose.js
@@ -48,6 +48,7 @@ ROS3D.Pose.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'geometry_msgs/PoseStamped'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/PoseArray.js
+++ b/src/navigation/PoseArray.js
@@ -46,6 +46,7 @@ ROS3D.PoseArray.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
      ros : this.ros,
      name : this.topicName,
+     queue_length : 1,
      messageType : 'geometry_msgs/PoseArray'
  });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/navigation/PoseWithCovariance.js
+++ b/src/navigation/PoseWithCovariance.js
@@ -44,6 +44,7 @@ ROS3D.PoseWithCovariance.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'geometry_msgs/PoseWithCovarianceStamped'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/sensors/LaserScan.js
+++ b/src/sensors/LaserScan.js
@@ -45,6 +45,7 @@ ROS3D.LaserScan.prototype.subscribe = function(){
     ros : this.ros,
     name : this.topicName,
     compression : this.compression,
+    queue_length : 1,
     messageType : 'sensor_msgs/LaserScan'
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));

--- a/src/sensors/NavSatFix.js
+++ b/src/sensors/NavSatFix.js
@@ -61,6 +61,7 @@ ROS3D.NavSatFix.prototype.subscribe = function(){
   this.rosTopic = new ROSLIB.Topic({
       ros : this.ros,
       name : this.topicName,
+      queue_length : 1,
       messageType : 'sensor_msgs/NavSatFix'
   });
 

--- a/src/sensors/PointCloud2.js
+++ b/src/sensors/PointCloud2.js
@@ -85,6 +85,7 @@ ROS3D.PointCloud2.prototype.subscribe = function(){
     ros : this.ros,
     name : this.topicName,
     messageType : 'sensor_msgs/PointCloud2',
+    queue_length : 1,
     compression: this.compression
   });
   this.rosTopic.subscribe(this.processMessage.bind(this));


### PR DESCRIPTION
When visualizing topics where the entire state is contained in each message, we only care about the most recent state.  Using a single item queue allows the server to replace a pending outgoing message with a newer message, instead of guaranteeing that every message is sent.

These visualizers are now unreliable:

* OccupancyGrid
* Odometry
* Path
* Point
* Polygon
* Pose
* PoseArray
* PoseWithCovariance
* LaserScan
* NavSatFix
* PointCloud2

Marker topics remain unqueued, since they have a stateful protocol.