### PR TITLE
Use loose roslibjs version in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,6 @@
   "dependencies": {
     "eventemitter2": "^4.1.0",
     "threejs": "mrdoob/three.js#r89",
-    "roslibjs": "RobotWebTools/roslibjs#1.0.0"
+    "roslibjs": "RobotWebTools/roslibjs#^1.0.1"
   }
 }


### PR DESCRIPTION
We don't want to lock in roslibjs 1.0.0 bugs forever.