### PR TITLE
Refactor mesh loading

### DIFF
--- a/es6-support/index.js
+++ b/es6-support/index.js
@@ -17,6 +17,7 @@ export * from './models/Arrow'
 export * from './models/Arrow2'
 export * from './models/Axes'
 export * from './models/Grid'
+export * from './models/MeshLoader'
 export * from './models/MeshResource'
 export * from './models/TriangleList'
 

--- a/src/models/MeshLoader.js
+++ b/src/models/MeshLoader.js
@@ -1,0 +1,81 @@
+/**
+ * @author Jose Rojas - jrojas@redlinesolutions.co
+ */
+
+ /**
+  * MeshLoader is a singleton factory class for using various helper classes to
+  * load mesh files of different types.
+  *
+  * It consists of one dictionary property 'loaders'. The dictionary keys consist
+  * of the file extension for each supported loader type. The dictionary values
+  * are functions used to construct the loader objects. The functions have the
+  * following parameters:
+  *
+  *  * meshRes - the MeshResource that will contain the loaded mesh
+  *  * uri - the uri path to the mesh file
+  *  @returns loader object
+  */
+ROS3D.MeshLoader = {
+   loaders: {
+     'dae': function(meshRes, uri, options) {
+       const material = options.material;
+       const loader = new THREE.ColladaLoader();
+       loader.log = function(message) {
+         if (meshRes.warnings) {
+           console.warn(message);
+         }
+       };
+       loader.load(
+         uri,
+         function colladaReady(collada) {
+           // check for a scale factor in ColladaLoader2
+           // add a texture to anything that is missing one
+           if(material !== null) {
+             collada.scene.traverse(function(child) {
+               if(child instanceof THREE.Mesh) {
+                 if(child.material === undefined) {
+                   child.material = material;
+                 }
+               }
+             });
+           }
+
+           meshRes.add(collada.scene);
+         },
+         /*onProgress=*/null,
+         function onLoadError(error) {
+           console.error(error);
+         });
+         return loader;
+     },
+
+     'obj': function() {
+
+     },
+
+     'stl': function(meshRes, uri, options) {
+       const material = options.material;
+       const loader = new THREE.STLLoader();
+       {
+         loader.load(uri,
+                     function ( geometry ) {
+                       geometry.computeFaceNormals();
+                       var mesh;
+                       if(material !== null) {
+                         mesh = new THREE.Mesh( geometry, material );
+                       } else {
+                         mesh = new THREE.Mesh( geometry,
+                                                new THREE.MeshBasicMaterial( { color: 0x999999 } ) );
+                       }
+                       meshRes.add(mesh);
+                     },
+                     /*onProgress=*/null,
+                     function onLoadError(error) {
+                       console.error(error);
+                     });
+       }
+       return loader;
+     }
+
+   }
+ }

--- a/src/models/MeshLoader.js
+++ b/src/models/MeshLoader.js
@@ -48,11 +48,7 @@ ROS3D.MeshLoader = {
          });
          return loader;
      },
-
-     'obj': function() {
-
-     },
-
+     
      'stl': function(meshRes, uri, options) {
        const material = options.material;
        const loader = new THREE.STLLoader();

--- a/src/models/MeshResource.js
+++ b/src/models/MeshResource.js
@@ -31,58 +31,14 @@ ROS3D.MeshResource = function(options) {
   }
 
   var uri = path + resource;
-  var fileType = uri.substr(-4).toLowerCase();
+  var fileType = uri.substr(-3).toLowerCase();
 
   // check the type
-  var loader;
-  if (fileType === '.dae') {
-    loader = new THREE.ColladaLoader();
-    loader.log = function(message) {
-      if (that.warnings) {
-        console.warn(message);
-      }
-    };
-    loader.load(
-      uri,
-      function colladaReady(collada) {
-        // check for a scale factor in ColladaLoader2
-        // add a texture to anything that is missing one
-        if(material !== null) {
-          collada.scene.traverse(function(child) {
-            if(child instanceof THREE.Mesh) {
-              if(child.material === undefined) {
-                child.material = material;
-              }
-            }
-          });
-        }
-
-        that.add(collada.scene);
-      },
-      /*onProgress=*/null,
-      function onLoadError(error) {
-        console.error(error);
-      });
-  } else if (fileType === '.stl') {
-    loader = new THREE.STLLoader();
-    {
-      loader.load(uri,
-                  function ( geometry ) {
-                    geometry.computeFaceNormals();
-                    var mesh;
-                    if(material !== null) {
-                      mesh = new THREE.Mesh( geometry, material );
-                    } else {
-                      mesh = new THREE.Mesh( geometry,
-                                             new THREE.MeshBasicMaterial( { color: 0x999999 } ) );
-                    }
-                    that.add(mesh);
-                  },
-                  /*onProgress=*/null,
-                  function onLoadError(error) {
-                    console.error(error);
-                  });
-    }
+  var loaderFunc = ROS3D.MeshLoader.loaders[fileType];
+  if (loaderFunc) {
+    loaderFunc(this, uri, options);
+  } else {
+    console.warn('Unsupported loader for file type: \'' + fileType + '\'');
   }
 };
 ROS3D.MeshResource.prototype.__proto__ = THREE.Object3D.prototype;

--- a/src/urdf/Urdf.js
+++ b/src/urdf/Urdf.js
@@ -47,10 +47,10 @@ ROS3D.Urdf = function(options) {
           if (tmpIndex !== -1) {
             uri = uri.substr(tmpIndex + ('package://').length);
           }
-          var fileType = uri.substr(-4).toLowerCase();
+          var fileType = uri.substr(-3).toLowerCase();
 
           // ignore mesh files which are not in Collada or STL format
-          if (fileType === '.dae' || fileType === '.stl') {
+          if (ROS3D.MeshLoader.loaders[fileType]) {
             // create the model
             var mesh = new ROS3D.MeshResource({
               path : path,

--- a/src/urdf/Urdf.js
+++ b/src/urdf/Urdf.js
@@ -49,7 +49,6 @@ ROS3D.Urdf = function(options) {
           }
           var fileType = uri.substr(-3).toLowerCase();
 
-          // ignore mesh files which are not in Collada or STL format
           if (ROS3D.MeshLoader.loaders[fileType]) {
             // create the model
             var mesh = new ROS3D.MeshResource({


### PR DESCRIPTION
Fix for #265 

This refactors the mesh loading into a MeshLoader object that has a list of supported loaders. If a developer wishes to add additional loaders, they can dynamically replace or add entries in the MeshLoader.loaders dictionary without modifying this library. 

Updated build files are not checked into this PR. If that's required for merge, let me know.