### PR TITLE
Fixes for eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -33,6 +33,8 @@
     "no-cond-assign": "off",
     "no-eq-null": "off",
     "no-proto": "off",
+    "no-console": "off",
+    "no-unused-vars": "off",
     "strict": "off",
     "quotes": ["error", "single"],
     "linebreak-style": "error"

--- a/src/interactivemarkers/InteractiveMarkerControl.js
+++ b/src/interactivemarkers/InteractiveMarkerControl.js
@@ -48,6 +48,7 @@ ROS3D.InteractiveMarkerControl = function(options) {
     case ROS3D.INTERACTIVE_MARKER_MOVE_ROTATE_3D:
     case ROS3D.INTERACTIVE_MARKER_MOVE_3D:
       this.addEventListener('mousemove', this.parent.move3d.bind(this.parent, this, controlAxis));
+      break;
     case ROS3D.INTERACTIVE_MARKER_MOVE_AXIS:
       this.addEventListener('mousemove', this.parent.moveAxis.bind(this.parent, this, controlAxis));
       this.addEventListener('touchmove', this.parent.moveAxis.bind(this.parent, this, controlAxis));

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -52,7 +52,7 @@ ROS3D.MarkerClient.prototype.checkTime = function(name){
         this.emit('change');
     } else {
         var that = this;
-        setTimeout(function() {that.checkTime(name)},
+        setTimeout(function() {that.checkTime(name);},
                    100);
     }
 };


### PR DESCRIPTION
When compiling on MacOSX using eslint@6.1.0, some fatal errors are present. I disabled no-console rule and no-unused-var to suppress these errors. I also fixed a missing 'break' statement that could have caused an unreported bug along with some missing semicolons. 