### PR TITLE
fix MarkerClient in ros3d.js to support Marker.DELETE action

### DIFF
--- a/build/ros3d.js
+++ b/build/ros3d.js
@@ -53264,11 +53264,6 @@ class MarkerClient extends eventemitter2 {
   };
 
   processMessage(message){
-    var newMarker = new Marker({
-      message : message,
-      path : this.path,
-    });
-
     // remove old marker from Three.Object3D children buffer
     var oldNode = this.markers[message.ns + message.id];
     this.updatedTime[message.ns + message.id] = new Date().getTime();
@@ -53279,12 +53274,19 @@ class MarkerClient extends eventemitter2 {
       this.checkTime(message.ns + message.id);
     }
 
-    this.markers[message.ns + message.id] = new SceneNode({
-      frameID : message.header.frame_id,
-      tfClient : this.tfClient,
-      object : newMarker
-    });
-    this.rootObject.add(this.markers[message.ns + message.id]);
+    if (message.action==0) { // add marker only when message.action is ADD
+      var newMarker = new Marker({
+        message : message,
+        path : this.path,
+      });
+
+      this.markers[message.ns + message.id] = new SceneNode({
+        frameID : message.header.frame_id,
+        tfClient : this.tfClient,
+        object : newMarker
+      });
+      this.rootObject.add(this.markers[message.ns + message.id]);
+    }
 
     this.emit('change');
   };

--- a/build/ros3d.js
+++ b/build/ros3d.js
@@ -53264,6 +53264,11 @@ class MarkerClient extends eventemitter2 {
   };
 
   processMessage(message){
+    var newMarker = new Marker({
+      message : message,
+      path : this.path,
+    });
+
     // remove old marker from Three.Object3D children buffer
     var oldNode = this.markers[message.ns + message.id];
     this.updatedTime[message.ns + message.id] = new Date().getTime();
@@ -53274,19 +53279,12 @@ class MarkerClient extends eventemitter2 {
       this.checkTime(message.ns + message.id);
     }
 
-    if (message.action==0) { // add marker only when message.action is ADD
-      var newMarker = new Marker({
-        message : message,
-        path : this.path,
-      });
-
-      this.markers[message.ns + message.id] = new SceneNode({
-        frameID : message.header.frame_id,
-        tfClient : this.tfClient,
-        object : newMarker
-      });
-      this.rootObject.add(this.markers[message.ns + message.id]);
-    }
+    this.markers[message.ns + message.id] = new SceneNode({
+      frameID : message.header.frame_id,
+      tfClient : this.tfClient,
+      object : newMarker
+    });
+    this.rootObject.add(this.markers[message.ns + message.id]);
 
     this.emit('change');
   };

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -71,11 +71,6 @@ ROS3D.MarkerClient.prototype.subscribe = function(){
 };
 
 ROS3D.MarkerClient.prototype.processMessage = function(message){
-  var newMarker = new ROS3D.Marker({
-    message : message,
-    path : this.path,
-  });
-
   // remove old marker from Three.Object3D children buffer
   var oldNode = this.markers[message.ns + message.id];
   this.updatedTime[message.ns + message.id] = new Date().getTime();
@@ -86,12 +81,19 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
     this.checkTime(message.ns + message.id);
   }
 
-  this.markers[message.ns + message.id] = new ROS3D.SceneNode({
-    frameID : message.header.frame_id,
-    tfClient : this.tfClient,
-    object : newMarker
-  });
-  this.rootObject.add(this.markers[message.ns + message.id]);
+  if (message.action === 0) {  // "ADD" or "MODIFY"
+    var newMarker = new ROS3D.Marker({
+      message : message,
+      path : this.path,
+    });
+
+    this.markers[message.ns + message.id] = new ROS3D.SceneNode({
+      frameID : message.header.frame_id,
+      tfClient : this.tfClient,
+      object : newMarker
+    });
+    this.rootObject.add(this.markers[message.ns + message.id]);
+  }
 
   this.emit('change');
 };


### PR DESCRIPTION
As I wrote in issue #277 (Marker cannot be deleted), MarkerClient does not support Marker.DELETE action.
I create a pull-request in order to fix this bug.
