### PR TITLE
fix the video tag's crossOrigin value in DepthCloud class

### DIFF
--- a/build/ros3d.js
+++ b/build/ros3d.js
@@ -46182,6 +46182,7 @@ class DepthCloud extends THREE$1.Object3D {
     this.isMjpeg = this.streamType.toLowerCase() === 'mjpeg';
 
     this.video = document.createElement(this.isMjpeg ? 'img' : 'video');
+    this.video.crossOrigin = 'Anonymous';
     this.video.addEventListener(this.isMjpeg ? 'load' : 'loadedmetadata', this.metaLoaded.bind(this), false);
 
     if (!this.isMjpeg) {
@@ -46189,7 +46190,6 @@ class DepthCloud extends THREE$1.Object3D {
     }
 
     this.video.src = this.url;
-    this.video.crossOrigin = 'Anonymous';
     this.video.setAttribute('crossorigin', 'Anonymous');
 
     // define custom shaders

--- a/build/ros3d.js
+++ b/build/ros3d.js
@@ -46182,7 +46182,6 @@ class DepthCloud extends THREE$1.Object3D {
     this.isMjpeg = this.streamType.toLowerCase() === 'mjpeg';
 
     this.video = document.createElement(this.isMjpeg ? 'img' : 'video');
-    this.video.crossOrigin = 'Anonymous';
     this.video.addEventListener(this.isMjpeg ? 'load' : 'loadedmetadata', this.metaLoaded.bind(this), false);
 
     if (!this.isMjpeg) {
@@ -46190,6 +46189,7 @@ class DepthCloud extends THREE$1.Object3D {
     }
 
     this.video.src = this.url;
+    this.video.crossOrigin = 'Anonymous';
     this.video.setAttribute('crossorigin', 'Anonymous');
 
     // define custom shaders

--- a/src/depthcloud/DepthCloud.js
+++ b/src/depthcloud/DepthCloud.js
@@ -36,6 +36,7 @@ ROS3D.DepthCloud = function(options) {
   this.isMjpeg = this.streamType.toLowerCase() === 'mjpeg';
 
   this.video = document.createElement(this.isMjpeg ? 'img' : 'video');
+  this.video.crossOrigin = 'Anonymous';
   this.video.addEventListener(this.isMjpeg ? 'load' : 'loadedmetadata', this.metaLoaded.bind(this), false);
 
   if (!this.isMjpeg) {
@@ -43,7 +44,6 @@ ROS3D.DepthCloud = function(options) {
   }
 
   this.video.src = this.url;
-  this.video.crossOrigin = 'Anonymous';
   this.video.setAttribute('crossorigin', 'Anonymous');
 
   // define custom shaders


### PR DESCRIPTION
As I wrote in DepthCloud streaming format error #173,

Fixing DepthCloud class code in fros3d.js is also needed to avoid DOMException (cross origin),
since this.video.crossOrigin='Anonymous' was set after 'this.video.loop = true;' and 'this.video.src = this.url'.

### Related issue:
* https://github.com/RobotWebTools/web_video_server/issues/91
* https://github.com/RobotWebTools/web_video_server/pull/92
