### PR TITLE
Memory leak fixes

### DIFF
--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -49,6 +49,10 @@ ROS3D.MarkerClient.prototype.checkTime = function(name){
         var oldNode = this.markers[name];
         oldNode.unsubscribeTf();
         this.rootObject.remove(oldNode);
+        oldNode.children.forEach(child => {
+          child.dispose();
+        });
+        delete(this.markers[name]);
         this.emit('change');
     } else {
         var that = this;
@@ -77,6 +81,10 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   if (oldNode) {
     oldNode.unsubscribeTf();
     this.rootObject.remove(oldNode);
+    oldNode.children.forEach(child => {
+      child.dispose();
+    });
+    delete(this.markers[message.ns + message.id]);
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
   }

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -46,13 +46,7 @@ ROS3D.MarkerClient.prototype.unsubscribe = function(){
 ROS3D.MarkerClient.prototype.checkTime = function(name){
     var curTime = new Date().getTime();
     if (curTime - this.updatedTime[name] > this.lifetime) {
-        var oldNode = this.markers[name];
-        oldNode.unsubscribeTf();
-        this.rootObject.remove(oldNode);
-        oldNode.children.forEach(child => {
-          child.dispose();
-        });
-        delete(this.markers[name]);
+        this.removeMarker(name)
         this.emit('change');
     } else {
         var that = this;
@@ -79,12 +73,8 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   var oldNode = this.markers[message.ns + message.id];
   this.updatedTime[message.ns + message.id] = new Date().getTime();
   if (oldNode) {
-    oldNode.unsubscribeTf();
-    this.rootObject.remove(oldNode);
-    oldNode.children.forEach(child => {
-      child.dispose();
-    });
-    delete(this.markers[message.ns + message.id]);
+    this.removeMarker(message.ns + message.id)
+
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
   }
@@ -105,3 +95,13 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
 
   this.emit('change');
 };
+
+ROS3D.MarkerClient.prototype.removeMarker = function(key) {
+  var oldNode = this.markers[key]
+  oldNode.unsubscribeTf();
+  this.rootObject.remove(oldNode);
+  oldNode.children.forEach(child => {
+    child.dispose();
+  });
+  delete(this.markers[message.ns + message.id]);
+}

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -46,7 +46,7 @@ ROS3D.MarkerClient.prototype.unsubscribe = function(){
 ROS3D.MarkerClient.prototype.checkTime = function(name){
     var curTime = new Date().getTime();
     if (curTime - this.updatedTime[name] > this.lifetime) {
-        this.removeMarker(name)
+        this.removeMarker(name);
         this.emit('change');
     } else {
         var that = this;
@@ -73,7 +73,7 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   var oldNode = this.markers[message.ns + message.id];
   this.updatedTime[message.ns + message.id] = new Date().getTime();
   if (oldNode) {
-    this.removeMarker(message.ns + message.id)
+    this.removeMarker(message.ns + message.id);
 
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
@@ -97,11 +97,11 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
 };
 
 ROS3D.MarkerClient.prototype.removeMarker = function(key) {
-  var oldNode = this.markers[key]
+  var oldNode = this.markers[key];
   oldNode.unsubscribeTf();
   this.rootObject.remove(oldNode);
   oldNode.children.forEach(child => {
     child.dispose();
   });
-  delete(this.markers[message.ns + message.id]);
-}
+  delete(this.markers[key]);
+};


### PR DESCRIPTION
I noticed markers weren't getting garbage collected leaving a memory leak that was particularly bad for an object tracking portion of a project. This MR properly disposes child components and deletes the reference to it from the markers object so JS knows it can be pulled from memory.

I also refactored this along with the existing portions into a `removeMarker` method since this happens in 2 places and there was repeated code.