### PR TITLE
Marker array memory leak fixes

### DIFF
--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -55,8 +55,7 @@ ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){
       if(message.ns + message.id in this.markers) { // "MODIFY"
         updated = this.markers[message.ns + message.id].children[0].update(message);
         if(!updated) { // "REMOVE"
-          this.markers[message.ns + message.id].unsubscribeTf();
-          this.rootObject.remove(this.markers[message.ns + message.id]);
+          this.removeMarker(message.ns + message.id);
         }
       }
       if(!updated) { // "ADD"
@@ -76,14 +75,11 @@ ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){
       console.warn('Received marker message with deprecated action identifier "1"');
     }
     else if(message.action === 2) { // "DELETE"
-      this.markers[message.ns + message.id].unsubscribeTf();
-      this.rootObject.remove(this.markers[message.ns + message.id]);
-      delete this.markers[message.ns + message.id];
+      this.removeMarker(message.ns + message.id);
     }
     else if(message.action === 3) { // "DELETE ALL"
       for (var m in this.markers){
-        this.markers[m].unsubscribeTf();
-        this.rootObject.remove(this.markers[m]);
+        this.removeMarker(m)
       }
       this.markers = {};
     }
@@ -99,4 +95,14 @@ ROS3D.MarkerArrayClient.prototype.unsubscribe = function(){
   if(this.rosTopic){
     this.rosTopic.unsubscribe();
   }
+};
+
+ROS3D.MarkerClient.prototype.removeMarker = function(key) {
+  var oldNode = this.markers[key];
+  oldNode.unsubscribeTf();
+  this.rootObject.remove(oldNode);
+  oldNode.children.forEach(child => {
+    child.dispose();
+  });
+  delete(this.markers[key]);
 };

--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -79,7 +79,7 @@ ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){
     }
     else if(message.action === 3) { // "DELETE ALL"
       for (var m in this.markers){
-        this.removeMarker(m)
+        this.removeMarker(m);
       }
       this.markers = {};
     }
@@ -99,6 +99,9 @@ ROS3D.MarkerArrayClient.prototype.unsubscribe = function(){
 
 ROS3D.MarkerClient.prototype.removeMarker = function(key) {
   var oldNode = this.markers[key];
+  if(!oldNode) {
+    return;
+  }
   oldNode.unsubscribeTf();
   this.rootObject.remove(oldNode);
   oldNode.children.forEach(child => {

--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -55,8 +55,7 @@ ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){
       if(message.ns + message.id in this.markers) { // "MODIFY"
         updated = this.markers[message.ns + message.id].children[0].update(message);
         if(!updated) { // "REMOVE"
-          this.markers[message.ns + message.id].unsubscribeTf();
-          this.rootObject.remove(this.markers[message.ns + message.id]);
+          this.removeMarker(message.ns + message.id);
         }
       }
       if(!updated) { // "ADD"
@@ -76,14 +75,11 @@ ROS3D.MarkerArrayClient.prototype.processMessage = function(arrayMessage){
       console.warn('Received marker message with deprecated action identifier "1"');
     }
     else if(message.action === 2) { // "DELETE"
-      this.markers[message.ns + message.id].unsubscribeTf();
-      this.rootObject.remove(this.markers[message.ns + message.id]);
-      delete this.markers[message.ns + message.id];
+      this.removeMarker(message.ns + message.id);
     }
     else if(message.action === 3) { // "DELETE ALL"
       for (var m in this.markers){
-        this.markers[m].unsubscribeTf();
-        this.rootObject.remove(this.markers[m]);
+        this.removeMarker(m);
       }
       this.markers = {};
     }
@@ -99,4 +95,17 @@ ROS3D.MarkerArrayClient.prototype.unsubscribe = function(){
   if(this.rosTopic){
     this.rosTopic.unsubscribe();
   }
+};
+
+ROS3D.MarkerClient.prototype.removeMarker = function(key) {
+  var oldNode = this.markers[key];
+  if(!oldNode) {
+    return;
+  }
+  oldNode.unsubscribeTf();
+  this.rootObject.remove(oldNode);
+  oldNode.children.forEach(child => {
+    child.dispose();
+  });
+  delete(this.markers[key]);
 };

--- a/src/markers/MarkerArrayClient.js
+++ b/src/markers/MarkerArrayClient.js
@@ -97,7 +97,7 @@ ROS3D.MarkerArrayClient.prototype.unsubscribe = function(){
   }
 };
 
-ROS3D.MarkerClient.prototype.removeMarker = function(key) {
+ROS3D.MarkerArrayClient.prototype.removeMarker = function(key) {
   var oldNode = this.markers[key];
   if(!oldNode) {
     return;

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -49,6 +49,10 @@ ROS3D.MarkerClient.prototype.checkTime = function(name){
         var oldNode = this.markers[name];
         oldNode.unsubscribeTf();
         this.rootObject.remove(oldNode);
+        oldNode.children.forEach(child => {
+          child.dispose();
+        });
+        delete(this.markers[name]);
         this.emit('change');
     } else {
         var that = this;
@@ -77,6 +81,10 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   if (oldNode) {
     oldNode.unsubscribeTf();
     this.rootObject.remove(oldNode);
+    oldNode.children.forEach(child => {
+      child.dispose();
+    });
+    delete(this.markers[message.ns + message.id]);
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
   }

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -98,6 +98,9 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
 
 ROS3D.MarkerClient.prototype.removeMarker = function(key) {
   var oldNode = this.markers[key];
+  if(!oldNode) {
+    return;
+  }
   oldNode.unsubscribeTf();
   this.rootObject.remove(oldNode);
   oldNode.children.forEach(child => {

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -46,13 +46,7 @@ ROS3D.MarkerClient.prototype.unsubscribe = function(){
 ROS3D.MarkerClient.prototype.checkTime = function(name){
     var curTime = new Date().getTime();
     if (curTime - this.updatedTime[name] > this.lifetime) {
-        var oldNode = this.markers[name];
-        oldNode.unsubscribeTf();
-        this.rootObject.remove(oldNode);
-        oldNode.children.forEach(child => {
-          child.dispose();
-        });
-        delete(this.markers[name]);
+        this.removeMarker(name)
         this.emit('change');
     } else {
         var that = this;
@@ -79,12 +73,8 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   var oldNode = this.markers[message.ns + message.id];
   this.updatedTime[message.ns + message.id] = new Date().getTime();
   if (oldNode) {
-    oldNode.unsubscribeTf();
-    this.rootObject.remove(oldNode);
-    oldNode.children.forEach(child => {
-      child.dispose();
-    });
-    delete(this.markers[message.ns + message.id]);
+    this.removeMarker(message.ns + message.id)
+
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
   }
@@ -105,3 +95,13 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
 
   this.emit('change');
 };
+
+ROS3D.MarkerClient.prototype.removeMarker = function(key) {
+  var oldNode = this.markers[key]
+  oldNode.unsubscribeTf();
+  this.rootObject.remove(oldNode);
+  oldNode.children.forEach(child => {
+    child.dispose();
+  });
+  delete(this.markers[message.ns + message.id]);
+}

--- a/src/markers/MarkerClient.js
+++ b/src/markers/MarkerClient.js
@@ -46,7 +46,7 @@ ROS3D.MarkerClient.prototype.unsubscribe = function(){
 ROS3D.MarkerClient.prototype.checkTime = function(name){
     var curTime = new Date().getTime();
     if (curTime - this.updatedTime[name] > this.lifetime) {
-        this.removeMarker(name)
+        this.removeMarker(name);
         this.emit('change');
     } else {
         var that = this;
@@ -73,7 +73,7 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
   var oldNode = this.markers[message.ns + message.id];
   this.updatedTime[message.ns + message.id] = new Date().getTime();
   if (oldNode) {
-    this.removeMarker(message.ns + message.id)
+    this.removeMarker(message.ns + message.id);
 
   } else if (this.lifetime) {
     this.checkTime(message.ns + message.id);
@@ -97,11 +97,11 @@ ROS3D.MarkerClient.prototype.processMessage = function(message){
 };
 
 ROS3D.MarkerClient.prototype.removeMarker = function(key) {
-  var oldNode = this.markers[key]
+  var oldNode = this.markers[key];
   oldNode.unsubscribeTf();
   this.rootObject.remove(oldNode);
   oldNode.children.forEach(child => {
     child.dispose();
   });
-  delete(this.markers[message.ns + message.id]);
-}
+  delete(this.markers[key]);
+};


### PR DESCRIPTION
- Same problem fixed in the previous PR for MarkerClient (https://github.com/RobotWebTools/ros3djs/pull/302) existed on MarkerArrayClient.

- Also fix a race condition caused by the timeout in checkTime if a marker happened to be removed between the timeout creation and callback execution