### PR TITLE
Remove THREE.Group() and replace with THREE.Object3D().

### DIFF
--- a/shims/three/ColladaLoader.js
+++ b/shims/three/ColladaLoader.js
@@ -3136,7 +3136,7 @@ THREE.ColladaLoader.prototype = {
 
       } else {
 
-        object = (type === 'JOINT') ? new THREE.Bone() : new THREE.Group();
+        object = (type === 'JOINT') ? new THREE.Bone() : new THREE.Object3D();
 
         for (var i = 0; i < objects.length; i++) {
 
@@ -3281,7 +3281,7 @@ THREE.ColladaLoader.prototype = {
 
     function buildVisualScene(data) {
 
-      var group = new THREE.Group();
+      var group = new THREE.Object3D();
       group.name = data.name;
 
       var children = data.children;

--- a/shims/three/OBJLoader.js
+++ b/shims/three/OBJLoader.js
@@ -630,7 +630,7 @@ THREE.OBJLoader.prototype = {
 
 		state.finalize();
 
-		var container = new THREE.Group();
+		var container = new THREE.Object3D();
 		container.materialLibraries = [].concat( state.materialLibraries );
 
 		for ( var i = 0, l = state.objects.length; i < l; i ++ ) {


### PR DESCRIPTION
Groups change the render sort order globally, so using these in model loading may cause unintended side-effects.