### PR TITLE
Update occupancy grid rendering

### DIFF
--- a/src/navigation/OccupancyGrid.js
+++ b/src/navigation/OccupancyGrid.js
@@ -31,15 +31,8 @@ ROS3D.OccupancyGrid = function(options) {
       var mapI = col + ((height - row - 1) * width);
       // determine the value
       var data = message.data[mapI];
-      var val;
-      if (data === 100) {
-        val = 0;
-      } else if (data === 0) {
-        val = 255;
-      } else {
-        val = 127;
-      }
-
+      var val = data * 255 / 100;
+      
       // determine the index into the image data array
       var i = (col + (row * width)) * 3;
       // r
@@ -53,8 +46,8 @@ ROS3D.OccupancyGrid = function(options) {
 
   var texture = new THREE.DataTexture(imageData, width, height, THREE.RGBFormat);
   texture.flipY = true;
-  texture.minFilter = THREE.LinearFilter;
-  texture.magFilter = THREE.LinearFilter;
+  texture.minFilter = THREE.NearestFilter;
+  texture.magFilter = THREE.NearestFilter;
   texture.needsUpdate = true;
 
   var material = new THREE.MeshBasicMaterial({


### PR DESCRIPTION
Use raw probabilities values from the occupancy grid as part of the color scale instead of encoding them as only 3 discrete values:

0 will be rendered as black, 100 as full color.

Do not use linear filtering, instead use nearest filter so the texture appears as a grid.

Here's what the rendering looks like:

[Rendering](https://tinyurl.com/yxaxytwx)

Update OccupancyGridClient to only add the scene node once instead of adding multiple scene nodes if there are multiple ROS updates.