### PR TITLE
Switch to Group for selectable objects. This offers better render control with renderOrder.

### DIFF
--- a/src/visualization/Viewer.js
+++ b/src/visualization/Viewer.js
@@ -80,7 +80,7 @@ ROS3D.Viewer = function(options) {
   this.scene.add(this.directionalLight);
 
   // propagates mouse events to three.js objects
-  this.selectableObjects = new THREE.Object3D();
+  this.selectableObjects = new THREE.Group();
   this.scene.add(this.selectableObjects);
   var mouseHandler = new ROS3D.MouseHandler({
     renderer : this.renderer,


### PR DESCRIPTION
Very simple change - use Group() instead of Object3D() for selectable objects group.