### PR TITLE
Refactor OccupancyGrid for subclassing.

### DIFF
--- a/src/navigation/OccupancyGrid.js
+++ b/src/navigation/OccupancyGrid.js
@@ -62,6 +62,8 @@ ROS3D.OccupancyGrid = function(options) {
   var data = message.data;
   // update the texture (after the the super call and this are accessible)
   this.color = color;
+  this.material = material;
+  this.texture = texture;
 
   for ( var row = 0; row < height; row++) {
     for ( var col = 0; col < width; col++) {
@@ -85,6 +87,11 @@ ROS3D.OccupancyGrid = function(options) {
 
   texture.needsUpdate = true;
 
+};
+
+ROS3D.OccupancyGrid.prototype.dispose = function() {
+  this.material.dispose();
+  this.texture.dispose();
 };
 
 /**

--- a/src/navigation/OccupancyGrid.js
+++ b/src/navigation/OccupancyGrid.js
@@ -106,7 +106,7 @@ ROS3D.OccupancyGrid.prototype.getValue = function(index, row, col, data) {
  * @param {int} row the row of the cell
  * @param {int} col the column of the cell
  * @param {float} value the value of the cell
- * @returns r,g,b array of values from 0 to 255 representing the color values for each channel
+ * @returns r,g,b,a array of values from 0 to 255 representing the color values for each channel
  */
 ROS3D.OccupancyGrid.prototype.getColor = function(index, row, col, value) {
   return [

--- a/src/navigation/OccupancyGrid.js
+++ b/src/navigation/OccupancyGrid.js
@@ -14,37 +14,20 @@
  */
 ROS3D.OccupancyGrid = function(options) {
   options = options || {};
-  var message = options.message;
-  var color = options.color || {r:255,g:255,b:255};
+  var message = options.message;  
   var opacity = options.opacity || 1.0;
+  var color = options.color || {r:255,g:255,b:255,a:255};
 
   // create the geometry
-  var width = message.info.width;
-  var height = message.info.height;
+  var info = message.info;
+  var origin = info.origin;
+  var width = info.width;
+  var height = info.height;
   var geom = new THREE.PlaneBufferGeometry(width, height);
 
   // create the color material
-  var imageData = new Uint8Array(width * height * 3);
-  for ( var row = 0; row < height; row++) {
-    for ( var col = 0; col < width; col++) {
-      // determine the index into the map data
-      var mapI = col + ((height - row - 1) * width);
-      // determine the value
-      var data = message.data[mapI];
-      var val = data * 255 / 100;
-      
-      // determine the index into the image data array
-      var i = (col + (row * width)) * 3;
-      // r
-      imageData[i] = (val * color.r) / 255;
-      // g
-      imageData[++i] = (val * color.g) / 255;
-      // b
-      imageData[++i] = (val * color.b) / 255;
-    }
-  }
-
-  var texture = new THREE.DataTexture(imageData, width, height, THREE.RGBFormat);
+  var imageData = new Uint8Array(width * height * 4);
+  var texture = new THREE.DataTexture(imageData, width, height, THREE.RGBAFormat);
   texture.flipY = true;
   texture.minFilter = THREE.NearestFilter;
   texture.magFilter = THREE.NearestFilter;
@@ -60,16 +43,78 @@ ROS3D.OccupancyGrid = function(options) {
   // create the mesh
   THREE.Mesh.call(this, geom, material);
   // move the map so the corner is at X, Y and correct orientation (informations from message.info)
+
+  // assign options to this for subclasses
+  Object.assign(this, options);
+
   this.quaternion.copy(new THREE.Quaternion(
-      message.info.origin.orientation.x,
-      message.info.origin.orientation.y,
-      message.info.origin.orientation.z,
-      message.info.origin.orientation.w
+      origin.orientation.x,
+      origin.orientation.y,
+      origin.orientation.z,
+      origin.orientation.w
   ));
-  this.position.x = (width * message.info.resolution) / 2 + message.info.origin.position.x;
-  this.position.y = (height * message.info.resolution) / 2 + message.info.origin.position.y;
-  this.position.z = message.info.origin.position.z;
-  this.scale.x = message.info.resolution;
-  this.scale.y = message.info.resolution;
+  this.position.x = (width * info.resolution) / 2 + origin.position.x;
+  this.position.y = (height * info.resolution) / 2 + origin.position.y;
+  this.position.z = origin.position.z;
+  this.scale.x = info.resolution;
+  this.scale.y = info.resolution;
+    
+  var data = message.data;
+  // update the texture (after the the super call and this are accessible)
+  this.color = color;
+
+  for ( var row = 0; row < height; row++) {
+    for ( var col = 0; col < width; col++) {
+      
+      // determine the index into the map data
+      var invRow = (height - row - 1);
+      var mapI = col + (invRow * width);
+      // determine the value      
+      var val = this.getValue(mapI, invRow, col, data);
+            
+      // determine the color
+      var color = this.getColor(mapI, invRow, col, val);
+
+      // determine the index into the image data array
+      var i = (col + (row * width)) * 4;
+
+      // copy the color
+      imageData.set(color, i);
+    }
+  }
+
+  texture.needsUpdate = true;
+
 };
+
+/**
+ * Returns the value for a given grid cell
+ * @param {int} index the current index of the cell
+ * @param {int} row the row of the cell
+ * @param {int} col the column of the cell
+ * @param {object} data the data buffer
+ */
+ROS3D.OccupancyGrid.prototype.getValue = function(index, row, col, data) {
+  return data[index];
+};
+
+/**
+ * Returns a color value given parameters of the position in the grid; the default implementation
+ * scales the default color value by the grid value. Subclasses can extend this functionality
+ * (e.g. lookup a color in a color map).
+ * @param {int} index the current index of the cell
+ * @param {int} row the row of the cell
+ * @param {int} col the column of the cell
+ * @param {float} value the value of the cell
+ * @returns r,g,b array of values from 0 to 255 representing the color values for each channel
+ */
+ROS3D.OccupancyGrid.prototype.getColor = function(index, row, col, value) {
+  return [
+    (value * this.color.r) / 255,
+    (value * this.color.g) / 255,
+    (value * this.color.b) / 255,
+    255
+  ];
+};
+
 ROS3D.OccupancyGrid.prototype.__proto__ = THREE.Mesh.prototype;

--- a/src/navigation/OccupancyGridClient.js
+++ b/src/navigation/OccupancyGridClient.js
@@ -74,6 +74,7 @@ ROS3D.OccupancyGridClient.prototype.processMessage = function(message){
       this.currentGrid.unsubscribeTf();
     }
     this.sceneNode.remove(this.currentGrid);
+    this.currentGrid.dispose();
   }
 
   var newGrid = new ROS3D.OccupancyGrid({


### PR DESCRIPTION
Refactor OccupancyGrid to add two methods. These methods can be overwritten by subclasses to
extend the OccupancyGrid's rendering behavior (for example adding a colormapping feature).

* getColor() - determine the color for a data cell
* getValue() - determine the value for a data cell