### PR TITLE
Fix transpiler

### DIFF
--- a/es6-transpiler.js
+++ b/es6-transpiler.js
@@ -222,7 +222,7 @@ const transpile = {
   exportedProperties: (filepath) => [
     // from:
     // ROS3D.MARKER_ARROW = 0;
-    /\nROS3D\.(.*)\s*=\s*(.*)/g,
+    /\nROS3D\.(\S*)\s*=\s*(.*)/g,
     // to:
     // export var MARKER_ARROW = 0;
     (match, $1, $2) => {

--- a/es6-transpiler.js
+++ b/es6-transpiler.js
@@ -20,7 +20,10 @@ const stringifyObjects = (...args) => args
     : arg)
 
 const logError = debug('ES6Transpiler:Error')
-logError.log = (...args) => console.error(...stringifyObjects(...args))
+logError.log = (...args) => {
+  console.error(...stringifyObjects(...args))
+  throw new Error("Execution stopped because of an error, sea above.")
+}
 logError.color = colors.RED
 
 const logWarning = debug('ES6Transpiler:Warning')

--- a/es6-transpiler.js
+++ b/es6-transpiler.js
@@ -1,6 +1,8 @@
 const debug = require('debug')
 const path = require('path')
 
+debug.enable('ES6Transpiler:Error')
+
 const colors = {
   GRAY: 0,
   RED: 1,


### PR DESCRIPTION
**Public API Changes**
None


**Description**
Transpiler wasn't working for exported properties, because of a broken regex. Which resulted in whitespace being added to property names.
