### PR TITLE
Update CDNs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ ros3djs depends on:
 
 [EventEmitter2](https://github.com/hij1nx/EventEmitter2). The current supported version is 6.4. The current supported version can be found on the JsDeliver CDN: ([full](https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js)) | ([min](https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.min.js))
 
-[three.js](https://github.com/mrdoob/three.js/). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ([full](https://static.robotwebtools.org/threejs/r89/three.js)) | ([min](https://static.robotwebtools.org/threejs/r89/three.min.js))
+[three.js](https://github.com/mrdoob/three.js/). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ([full](https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.js)) | ([min](https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js))
 
-[THREE.ColladaLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/ColladaLoader.js). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ([full](https://static.robotwebtools.org/threejs/r89/ColladaLoader.js))
+[THREE.ColladaLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/ColladaLoader.js). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ~([full](https://static.robotwebtools.org/threejs/r89/ColladaLoader.js))~ This CDN is gone.
 
-[THREE.STLLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/STLLoader.js). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ([full](https://static.robotwebtools.org/threejs/r89/STLLoader.js))
+[THREE.STLLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/STLLoader.js). The current supported version is r89. The current supported version can be found on the Robot Web Tools CDN: ~([full](https://static.robotwebtools.org/threejs/r89/STLLoader.js))~ This CDN is gone.
 
-(ROS)ColladaLoader. We support patched version of ColladaLoader to workaround ros-visualization/rviz#1045. This version can be found on the Robot Web Tools CDN: ([full](https://static.robotwebtools.org/ros3djs/0.18.0/ColladaLoader.js))
+(ROS)ColladaLoader. We support patched version of ColladaLoader to workaround ros-visualization/rviz#1045. This version can be found on the Robot Web Tools CDN: ~([full](https://static.robotwebtools.org/ros3djs/0.18.0/ColladaLoader.js))~ This CDN is gone.
 
 [roslibjs](https://github.com/RobotWebTools/roslibjs). The current supported version is 1.3.0. The current supported version can be found on the JsDeliver CDN: ([full](https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js)) | ([min](https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.min.js))
 

--- a/examples/continuousmap.html
+++ b/examples/continuousmap.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/depthcloud.html
+++ b/examples/depthcloud.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/html-import/markers.html
+++ b/examples/html-import/markers.html
@@ -1,6 +1,6 @@
 <html>
   <head>
-    <script src="https://static.robotwebtools.org/roslibjs/current/roslib.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
     <script type="module">
       import * as ROS3D from './node_modules/ros3d/build/ros3d.esm.js'
 

--- a/examples/interactivemarkers.html
+++ b/examples/interactivemarkers.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/kitti.html
+++ b/examples/kitti.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/map.html
+++ b/examples/map.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/markers.html
+++ b/examples/markers.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/navsatfix.html
+++ b/examples/navsatfix.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/octree.html
+++ b/examples/octree.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/pointcloud2.html
+++ b/examples/pointcloud2.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>

--- a/examples/urdf.html
+++ b/examples/urdf.html
@@ -3,9 +3,9 @@
 <head>
 <meta charset="utf-8" />
 
-<script src="https://static.robotwebtools.org/threejs/r89/three.js"></script>
-<script src="https://static.robotwebtools.org/threejs/current/ColladaLoader.js"></script>
-<script src="https://static.robotwebtools.org/threejs/current/STLLoader.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/three@0.89.0/build/three.min.js"></script>
+<!-- <script src="https://static.robotwebtools.org/threejs/current/ColladaLoader.js"></script> --><!-- CDN is gone -->
+<!-- <script src="https://static.robotwebtools.org/threejs/current/STLLoader.js"></script> --><!-- CDN is gone -->
 <script src="https://cdn.jsdelivr.net/npm/eventemitter2@6.4/lib/eventemitter2.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/roslib@1/build/roslib.js"></script>
 <script src="../build/ros3d.js"></script>


### PR DESCRIPTION
Migrated Three/ROSLIB to jsdeliver.
Custom Three loaders are gone.

Related to https://github.com/RobotWebTools/robotwebtools.github.io/issues/82